### PR TITLE
fix(getRegistryByType): detect .npmrc

### DIFF
--- a/lib/init_command.js
+++ b/lib/init_command.js
@@ -268,11 +268,11 @@ module.exports = class Command {
         if (/^https?:/.test(key)) {
           return key;
         } else {
-          // support .npmrc
           const home = homedir();
           let url = process.env.npm_registry || process.env.npm_config_registry || 'https://registry.cnpmjs.org';
-          if (fs.existsSync(path.join(home, '.cnpmrc')) || fs.existsSync(path.join(home, '.tnpmrc'))) {
-            url = 'https://registry.npm.taobao.org';
+          if (fs.existsSync(path.join(home, '.cnpmrc')) || fs.existsSync(path.join(home, '.tnpmrc')) || fs.existsSync(path.join(home, '.npmrc'))) {
+            // support user with custom .npmrc
+            url = fs.readFileSync(path.join(home, '.npmrc'), 'utf8').replace(/registry=/, '').trim() || 'https://registry.npm.taobao.org';
           }
           url = url.replace(/\/$/, '');
           return url;


### PR DESCRIPTION
fix a bug which leads to an error when npm user with custom `.npmrc` downloading boilerplate.