### PR TITLE
Registry of npm-updater should be set

### DIFF
--- a/lib/init_command.js
+++ b/lib/init_command.js
@@ -47,6 +47,7 @@ module.exports = class Command {
     // check update
     yield updater({
       package: this.pkgInfo,
+      registry: this.registryUrl,
       level: 'major',
     });
 
@@ -276,7 +277,7 @@ module.exports = class Command {
         return 'https://registry.npmjs.org';
       default: {
         if (/^https?:/.test(key)) {
-          return key;
+          return key.replace(/\/$/, '');
         } else {
           // support .npmrc
           const home = homedir();


### PR DESCRIPTION
- 设置了npm-updater模块的registry

npmjs.org完全被墙时会报错
> TypeError: Cannot read property 'type' of undefined