### PR TITLE
fix: shouldn't use fs.readFileSync('xxx', {encoding: 'utf-8'}) to read binary files

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
 
+1.17.0 / 2019-04-17
+==================
+
+**features**
+  * [[`36f2d86`](http://github.com/eggjs/egg-init/commit/36f2d86493f466a603cbd9bd40d76eab969d1e04)] - feat: question support other type from inquirer (#51) (Haoliang Gao <<sakura9515@gmail.com>>)
+
 1.16.1 / 2019-03-28
 ==================
 

--- a/lib/init_command.js
+++ b/lib/init_command.js
@@ -247,11 +247,12 @@ module.exports = class Command {
       return yield inquirer.prompt(keys.map(key => {
         const question = questions[key];
         return {
-          type: 'input',
+          type: question.type || 'input',
           name: key,
           message: question.description || question.desc,
           default: question.default,
           filter: question.filter,
+          choices: question.choices,
         };
       }));
     }

--- a/lib/init_command.js
+++ b/lib/init_command.js
@@ -271,16 +271,13 @@ module.exports = class Command {
     files.forEach(file => {
       const from = path.join(src, file);
       const to = path.join(targetDir, this.replaceTemplate(this.fileMapping[file] || file, locals));
-
-      let result;
       const content = fs.readFileSync(from);
-      if (isTextOrBinary.isTextSync(from, content)) {
-        result = this.replaceTemplate(content.toString('utf8'), locals);
-      } else {
-        result = fs.readFileSync(from);
-      }
-
       this.log('write to %s', to);
+
+      // check if content is a text file
+      const result = isTextOrBinary.isTextSync(from, content)
+        ? this.replaceTemplate(content.toString('utf-8'), locals)
+        : content;
 
       mkdirp.sync(path.dirname(to));
       fs.writeFileSync(to, result);

--- a/lib/init_command.js
+++ b/lib/init_command.js
@@ -270,13 +270,16 @@ module.exports = class Command {
     files.forEach(file => {
       const from = path.join(src, file);
       const to = path.join(targetDir, this.replaceTemplate(this.fileMapping[file] || file, locals));
-      const content = fs.readFileSync(from, { encoding: 'utf-8' });
-      this.log('write to %s', to);
 
-      // check if content is a text file
-      const result = isTextOrBinary.isTextSync(from, content)
-        ? this.replaceTemplate(content, locals)
-        : content;
+      let result;
+      const content = fs.readFileSync(from);
+      if (isTextOrBinary.isTextSync(from, content)) {
+        result = this.replaceTemplate(content.toString('utf8'), locals);
+      } else {
+        result = fs.readFileSync(from);
+      }
+
+      this.log('write to %s', to);
 
       mkdirp.sync(path.dirname(to));
       fs.writeFileSync(to, result);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-init",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "Init egg app helper tools.",
   "main": "lib/init_command.js",
   "scripts": {

--- a/test/category.test.js
+++ b/test/category.test.js
@@ -44,7 +44,7 @@ describe('test/category.test', () => {
   });
 
   it('should work with prompt', function* () {
-    helper.mock([[ 'simple-app', 'this is xxx', 'TZ', helper.KEY_ENTER, 'test' ]]);
+    helper.mock([[ 'simple-app', 'this is xxx', 'TZ', helper.KEY_ENTER, 'test', helper.KEY_ENTER ]]);
     const boilerplatePath = path.join(__dirname, 'fixtures/simple-test');
     yield command.run(tmp, [ 'simple-app', '--force', '--template=' + boilerplatePath ]);
 

--- a/test/fixtures/simple-test/boilerplate/README.md
+++ b/test/fixtures/simple-test/boilerplate/README.md
@@ -6,6 +6,8 @@
 
 {{filterFn}}
 
+{{list}}
+
 ## QuickStart
 
 ### Development

--- a/test/fixtures/simple-test/index.js
+++ b/test/fixtures/simple-test/index.js
@@ -23,4 +23,9 @@ module.exports = {
       return 'filter-' + v;
     },
   },
+  list: {
+    type: 'list',
+    desc: 'choose',
+    choices: [ 'listA', 'listB' ],
+  },
 };

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -42,7 +42,7 @@ describe('test/init.test.js', () => {
   });
 
   it('should work with prompt', function* () {
-    helper.mock([[ 'simple-app', 'this is xxx', 'TZ', helper.KEY_ENTER, 'test' ]]);
+    helper.mock([[ 'simple-app', 'this is xxx', 'TZ', helper.KEY_ENTER, 'test', helper.KEY_ENTER ]]);
     const boilerplatePath = path.join(__dirname, 'fixtures/simple-test');
     yield command.run(tmp, [ 'simple-app', '--force', '--template=' + boilerplatePath ]);
 
@@ -55,6 +55,7 @@ describe('test/init.test.js', () => {
     const content = fs.readFileSync(path.join(command.targetDir, 'README.md'), 'utf-8');
     assert(/default-simple-app/.test(content));
     assert(/filter-test/.test(content));
+    assert(/listA/.test(content));
   });
 
   it('should prompt', function* () {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
When set encoding to read a binary file, such as: fs.readFileSync('./logo.png', {encoing: 'utf-8'}), the image will be corrupted when use fs.writeFileSync('./path/logo.png', data), so I removed the encoding settings.