### PR TITLE
fix: remove encoding setting to read files

### DIFF
--- a/lib/init_command.js
+++ b/lib/init_command.js
@@ -271,12 +271,12 @@ module.exports = class Command {
     files.forEach(file => {
       const from = path.join(src, file);
       const to = path.join(targetDir, this.replaceTemplate(this.fileMapping[file] || file, locals));
-      const content = fs.readFileSync(from, { encoding: 'utf-8' });
+      const content = fs.readFileSync(from);
       this.log('write to %s', to);
 
       // check if content is a text file
       const result = isTextOrBinary.isTextSync(from, content)
-        ? this.replaceTemplate(content, locals)
+        ? this.replaceTemplate(content.toString('utf8'), locals)
         : content;
 
       mkdirp.sync(path.dirname(to));


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
When set encoding to read a binary file, such as: fs.readFileSync('./logo.png', {encoing: 'utf-8'}), the image will be corrupted when use fs.writeFileSync('./path/logo.png', data), so I removed the encoding settings.