### PR TITLE
docs: update recommended package tool

### DIFF
--- a/lib/init_command.js
+++ b/lib/init_command.js
@@ -474,8 +474,8 @@ module.exports = class Command {
   printUsage() {
     this.log(`usage:
       - cd ${this.targetDir}
-      - npm install
-      - npm start / npm run dev / npm test
+      - pnpm install
+      - pnpm start / pnpm run dev / pnpm test
     `);
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

When I use `npm install` to install dependencies of an egg template project, according to my network(which takes most of the time), it spends about 2 minutes, it seems better to change the recommended tool to `pnpm` (which feels better: 43~44s)

### npm
```shell
mkdir && cd egg-npm
npm init egg --type=simple
/usr/bin/time npm install
......
135.93 real        14.79 user         6.42 sys
```

### pnpm
```
mkdir && cd egg-pnpm
pnpm create egg --type=simple
/usr/bin/time pnpm i
......
43.54 real         9.28 user         9.87 sys
```
